### PR TITLE
Force production environment traffic to use SSL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,4 +109,7 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  # force all server traffic to be SSL
+  config.force_ssl = true
 end


### PR DESCRIPTION
Is currently deployed on our staging server:
http://bullpen-staging.herokuapp.com - should forward to https